### PR TITLE
Move SchemaType to Subject Level

### DIFF
--- a/spec_cn.md
+++ b/spec_cn.md
@@ -58,7 +58,7 @@ OpenSchema REST服务器通过使用http+json的方式进行通信。
 | status        | 元数据状态               | 比如已发布、已废弃等            |
 | compatibility | 兼容性策略               | 无、向前兼容、向后兼容、全兼容  |
 | coordinate    | Maven坐标                | 消息Payload的JAR的Maven坐标     |
-| schemaType       | schema类型的枚举：NONE、JSON、PB、AVRO、USER-DEFINED、Int、Long、String、Map | 当消息都是没有提供Schema的，所以Schema类型都是NONE。 我们也可以给当前的消息加上Schema，比如用PB来描述RocketMQ 传输的数据的格式 |
+| type       | schema类型的枚举：NONE、JSON、PB、AVRO、USER-DEFINED、Int、Long、String、Map | 当消息都是没有提供Schema的，所以Schema类型都是NONE。 我们也可以给当前的消息加上Schema，比如用PB来描述RocketMQ 传输的数据的格式 |
 | schema        | 数据格式                 | 关联的数据格式描述，详见下表    |
 
 ### 5.2 Schema定义 
@@ -87,7 +87,7 @@ Payload Schema用于描述消息的Payload数据。
 	"compatibility": "NONE",
 	"validator": "a.groovy",
 	"comment": "Rocketmq user infomation",
-	"schemaType": "AVRO",
+	"type": "AVRO",
 	"schemaDefinition": [{
 			"name": "id",
 			"type": "string"
@@ -547,7 +547,7 @@ curl -X GET http://localhost:8081/subjects/test-value/versions/1/schema
 	"app": "rocketmq",
 	"description": "rocketmq user information",
 	"compatibility": "NONE",
-	"schemaType": "AVRO",
+	"type": "AVRO",
 	"schema": {
 		"version": 1,
 		"id": "20",

--- a/spec_cn.md
+++ b/spec_cn.md
@@ -547,7 +547,7 @@ curl -X GET http://localhost:8081/subjects/test-value/versions/1/schema
 	"app": "rocketmq",
 	"description": "rocketmq user information",
 	"compatibility": "NONE",
-  "schemaType": "AVRO",
+	"schemaType": "AVRO",
 	"schema": {
 		"version": 1,
 		"id": "20",

--- a/spec_cn.md
+++ b/spec_cn.md
@@ -51,14 +51,14 @@ OpenSchema REST服务器通过使用http+json的方式进行通信。
 | 元信息        | 含义                     | 示例                            |
 | ------------- | ------------------------ | ------------------------------- |
 | tenant        | 租户                     | org/apache/rocketmq/mybank      |
-| namespace     | 命名空间                 | 集群名称, 如 rocketmq- cluster  |
+| namespace     | 命名空间                 | 集群名称, 如 rocketmq-cluster  |
 | subject       | 元数据的名称             | 比如使用Topic名称作为元数据名称 |
 | app           | 服务提供方的应用部署单元 |                                 |
 | description   | 描述信息                 | 由申请人提供                    |
 | status        | 元数据状态               | 比如已发布、已废弃等            |
 | compatibility | 兼容性策略               | 无、向前兼容、向后兼容、全兼容  |
 | coordinate    | Maven坐标                | 消息Payload的JAR的Maven坐标     |
-| type       | schema类型的枚举：NONE、JSON、PB、AVRO、USER-DEFINED、Int、Long、String、Map | 当消息都是没有提供Schema的，所以Schema类型都是NONE。 我们也可以给当前的消息加上Schema，比如用PB来描述RocketMQ 传输的数据的格式 |
+| type       | schema类型的枚举：NONE、JSON、PB、AVRO、USER-DEFINED、Int、Long、String、Map | NONE 表示不提供Schema。也可以给当前消息加上Schema，比如用PB来描述RocketMQ 传输的数据的格式 |
 | schema        | 数据格式                 | 关联的数据格式描述，详见下表    |
 
 ### 5.2 Schema定义 

--- a/spec_cn.md
+++ b/spec_cn.md
@@ -58,6 +58,7 @@ OpenSchema REST服务器通过使用http+json的方式进行通信。
 | status        | 元数据状态               | 比如已发布、已废弃等            |
 | compatibility | 兼容性策略               | 无、向前兼容、向后兼容、全兼容  |
 | coordinate    | Maven坐标                | 消息Payload的JAR的Maven坐标     |
+| schemaType       | schema类型的枚举：NONE、JSON、PB、AVRO、USER-DEFINED、Int、Long、String、Map | 当消息都是没有提供Schema的，所以Schema类型都是NONE。 我们也可以给当前的消息加上Schema，比如用PB来描述RocketMQ 传输的数据的格式 |
 | schema        | 数据格式                 | 关联的数据格式描述，详见下表    |
 
 ### 5.2 Schema定义 
@@ -70,7 +71,6 @@ Payload Schema用于描述消息的Payload数据。
 | id               | 全局唯一标识，用于确定该schema                               |                                                              |
 | comment          | payload注释说明                                              |                                                              |
 | serialization    | 序列化方式：hissian、json、pb、avro、user-defined            |                                                              |
-| schemaType       | schema类型的枚举：NONE、JSON、PB、AVRO、USER-DEFINED、Int、Long、String、Map | 当消息都是没有提供Schema的，所以Schema类型都是NONE。 我们也可以给当前的消息加上Schema，比如用PB来描述RocketMQ 传输的数据的格式 |
 | schemaDefinition | schema具体的内容，以一种方式来描述数据格式                   | NONE：无 PB：给出PB描述文件 AVRO：给出AVRO Schema内容 USER-DEFINED：给出用户自定义的信息 基础内容类型：无 |
 | validator        | 值校验器                                                     | 对Schema描述的对象的值进行校验                               |
 | version          | schema的版本信息                                             | 以消息为例，Payload可能会变，这个时候需要版本来标识区别不同的Schema |
@@ -205,8 +205,7 @@ curl -X GET http://localhost:8081/schema/ids/1
 {
 	"version": 1,
 	"id": "20",
-	"serialization": "PB",
-	"schemaType": "AVRO",
+	"serialization": "PB",	
 	"schemaDefinition": [{
 			"name": "id",
 			"type": "string"
@@ -548,11 +547,11 @@ curl -X GET http://localhost:8081/subjects/test-value/versions/1/schema
 	"app": "rocketmq",
 	"description": "rocketmq user information",
 	"compatibility": "NONE",
+  "schemaType": "AVRO",
 	"schema": {
 		"version": 1,
 		"id": "20",
-		"serialization": "PB",
-		"schemaType": "AVRO",
+		"serialization": "PB",		
 		"schemaDefinition": [{
 			"name": "id",
 			"type": "string"
@@ -620,8 +619,7 @@ curl -X GET http://localhost:8081/subjects/test-value/versions/1/schema
 curl -X POST -H "Content-Type: application/vnd.openschema.v1+json" \
 http://localhost:8081/subjects/test-value/versions --data '
 {
-	"serialization": "PB",
-	"schemaType": "AVRO",
+	"serialization": "PB",	
 	"schemaDefinition": [{
 		"name": "id",
 		"type": "string"

--- a/spec_en.md
+++ b/spec_en.md
@@ -60,7 +60,7 @@ The following Metadata-information describes Subject definition in OpenSchema sp
 | status | Subject status | For example, released or abandoned |
 | Compatibility | Compatibility setting | None, forward compatibility, backward compatibility, and full compatibility|
 | Coordinate | Maven coordinate | Maven coordinate of the JAR of the payload|
-| schemaType | Enumeration of schema types: NONE, JSON, PB, AVRO, USER-DEFINED, Int, Long, String, and Map | If no schema is provided in a message, the schema type is NONE. You can also add a schema to the current message. For example, you can use PB to describe the format of the data transmitted by the RocketMQ.
+| type | Enumeration of schema types: NONE, JSON, PB, AVRO, USER-DEFINED, Int, Long, String, and Map | If no schema is provided in a message, the schema type is NONE. You can also add a schema to the current message. For example, you can use PB to describe the format of the data transmitted by the RocketMQ.
 | schema | Data format | Associated data format description. For details, see the following table. |
 
 ### 5.2 Schema Definition
@@ -89,7 +89,7 @@ Example:
     "compatibility": "NONE",
     "validator": "a.groovy",
     "comment": "Rocketmq user infomation",
-    "schemaType": "AVRO",
+    "type": "AVRO",
     "schemaDefinition": [{
                 "name": "id",
                 "type": "string"
@@ -545,7 +545,7 @@ curl -X GET http://localhost:8081/subjects/test-value/versions/1/schema
     "app": "rocketmq",
     "description": "rocketmq user information",    
     "compatibility": "NONE",
-    "schemaType": "AVRO",
+    "type": "AVRO",
     "schema": {
         "version": 1,
         "id": "20",

--- a/spec_en.md
+++ b/spec_en.md
@@ -60,6 +60,7 @@ The following Metadata-information describes Subject definition in OpenSchema sp
 | status | Subject status | For example, released or abandoned |
 | Compatibility | Compatibility setting | None, forward compatibility, backward compatibility, and full compatibility|
 | Coordinate | Maven coordinate | Maven coordinate of the JAR of the payload|
+| schemaType | Enumeration of schema types: NONE, JSON, PB, AVRO, USER-DEFINED, Int, Long, String, and Map | If no schema is provided in a message, the schema type is NONE. You can also add a schema to the current message. For example, you can use PB to describe the format of the data transmitted by the RocketMQ.
 | schema | Data format | Associated data format description. For details, see the following table. |
 
 ### 5.2 Schema Definition
@@ -72,7 +73,6 @@ The Payload Schema is used to describe the payload data of a message.
 | id | Globally unique identifier, which is used to identify the schema | |
 | comment | Payload comment | |
 | Serialization | Serialization mode: Hissian, JSON, PB, AVRO, and user-defined | |
-| schemaType | Enumeration of schema types: NONE, JSON, PB, AVRO, USER-DEFINED, Int, Long, String, and Map | If no schema is provided in a message, the schema type is NONE. You can also add a schema to the current message. For example, you can use PB to describe the format of the data transmitted by the RocketMQ.
 | schemaDefinition | Schema content, which is used to describe the data format. | NONE: none PB: PB description file AVRO: AVRO schema content USER-DEFINED: user-defined information Basic content type: none |
 | Validator | Object value validator | Validates the values of objects described in the schema.|
 | version | Schema version | For example, the payload may change. In this case, the version is required to identify different schemas. |
@@ -207,8 +207,7 @@ curl -X GET http://localhost:8081/schema/ids/1
 {
     "version": 1,
     "id": "20",
-    "serialization": "PB",
-    "schemaType": "AVRO",
+    "serialization": "PB",    
     "schemaDefinition": [{
             "name": "id",
             "type": "string"
@@ -544,13 +543,13 @@ curl -X GET http://localhost:8081/subjects/test-value/versions/1/schema
     "namespace": "org.apache.rocketmq",
     "tenant": "messaging/rocketmq",
     "app": "rocketmq",
-    "description": "rocketmq user information",
+    "description": "rocketmq user information",    
     "compatibility": "NONE",
+    "schemaType": "AVRO",
     "schema": {
         "version": 1,
         "id": "20",
-        "serialization": "PB",
-        "schemaType": "AVRO",
+        "serialization": "PB",        
         "schemaDefinition": [
             {
                 "name": "id",
@@ -621,8 +620,7 @@ POST /subjects/(string: subject)/versions
 curl -X POST -H "Content-Type: application/vnd.openschema.v1+json" \
 http://localhost:8081/subjects/test-value/versions --data'
 {
-    "serialization": "PB",
-    "schemaType": "AVRO",
+    "serialization": "PB",    
     "schemaDefinition": [
         {
             "name": "id",


### PR DESCRIPTION
The purpose of this PR is for defining the SchemaType as part of Subject definition which constraints all versions belong to the same Subject must accommodate to the same SchemaType such as JSON or Avro and so on.  